### PR TITLE
Export MediaStoreClass interface

### DIFF
--- a/packages/tinacms/src/index.ts
+++ b/packages/tinacms/src/index.ts
@@ -79,7 +79,7 @@ export const defineLegacyConfig = (
   return config
 }
 
-interface MediaStoreClass {
+export interface MediaStoreClass {
   new (...args: any[]): MediaStore
 }
 


### PR DESCRIPTION
The `MediaStoreClass` interface is private and used by public exports, which then breaks TS compilation for projects using Tina.

